### PR TITLE
Added support for a new Proof type in the Bridge response

### DIFF
--- a/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/BridgeClient.kt
+++ b/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/BridgeClient.kt
@@ -1,18 +1,13 @@
 package com.worldcoin.idkit_kotlin
 
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
-import java.util.*
-import java.net.URL
-import java.net.HttpURLConnection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.UUID
 
 @Serializable(with = BridgeResponseSerializer::class)
 sealed class BridgeResponse {
@@ -21,34 +16,6 @@ sealed class BridgeResponse {
 
     @Serializable
     data class Error(val error: AppError) : BridgeResponse()
-}
-
-object BridgeResponseSerializer : KSerializer<BridgeResponse> {
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("BridgeResponse") {
-        element<Proof>("proof", isOptional = true)
-        element<AppError>("error_code", isOptional = true)
-    }
-
-    override fun serialize(encoder: Encoder, value: BridgeResponse) {
-
-    }
-
-    override fun deserialize(decoder: Decoder): BridgeResponse {
-        val jsonDecoder = decoder as? JsonDecoder ?: throw SerializationException("This class can be loaded only by JSON")
-        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
-
-        return when {
-            "error_code" in jsonObject -> {
-                val error = jsonDecoder.json.decodeFromJsonElement<AppError>(jsonObject["error_code"]!!)
-                BridgeResponse.Error(error)
-            }
-            "proof" in jsonObject -> {
-                val proof = jsonDecoder.json.decodeFromJsonElement<Proof>(jsonObject)
-                BridgeResponse.Success(proof)
-            }
-            else -> throw SerializationException("BridgeResponse doesn't match any expected type")
-        }
-    }
 }
 
 @Serializable
@@ -77,4 +44,3 @@ object BridgeClient {
         }
     }
 }
-

--- a/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/CustomSerializers.kt
+++ b/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/CustomSerializers.kt
@@ -1,0 +1,88 @@
+package com.worldcoin.idkit_kotlin
+
+import android.util.Log
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+internal object BridgeResponseSerializer : KSerializer<BridgeResponse> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("BridgeResponse") {
+        element<Proof>("proof", isOptional = true)
+        element<AppError>("error_code", isOptional = true)
+    }
+
+    override fun serialize(encoder: Encoder, value: BridgeResponse) {
+
+    }
+
+    override fun deserialize(decoder: Decoder): BridgeResponse {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("This class can be loaded only by JSON")
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+
+        return when {
+            "error_code" in jsonObject -> {
+                val error =
+                    jsonDecoder.json.decodeFromJsonElement<AppError>(jsonObject["error_code"]!!)
+                BridgeResponse.Error(error)
+            }
+
+            "proof" in jsonObject -> {
+                val proof = if ("verification_credential_result" in jsonObject) {
+                    jsonDecoder.json.decodeFromJsonElement<Proof.CredentialCategory>(jsonObject)
+                } else {
+                    jsonDecoder.json.decodeFromJsonElement<Proof.Default>(jsonObject)
+                }
+
+                BridgeResponse.Success(proof)
+            }
+
+            else -> throw SerializationException("BridgeResponse doesn't match any expected type")
+        }
+    }
+}
+
+internal object AppErrorSerializer : KSerializer<AppError> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("AppError", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: AppError) {
+        throw NotImplementedError("Serialization of AppError is not supported")
+    }
+
+    override fun deserialize(decoder: Decoder): AppError {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("This class can be loaded only by JSON")
+        val jsonPrimitive = jsonDecoder.decodeJsonElement().jsonPrimitive
+
+        val errorString = jsonPrimitive.content
+
+        return when (errorString) {
+            "connection_failed" -> AppError.ConnectionFailed
+            "verification_rejected" -> AppError.VerificationRejected
+            "max_verifications_reached" -> AppError.MaxVerificationsReached
+            "credential_unavailable" -> AppError.CredentialUnavailable
+            "malformed_request" -> AppError.MalformedRequest
+            "invalid_network" -> AppError.InvalidNetwork
+            "inclusion_proof_failed" -> AppError.InclusionProofFailed
+            "inclusion_proof_pending" -> AppError.InclusionProofPending
+            "unexpected_response" -> AppError.UnexpectedResponse
+            "failed_by_host_app" -> AppError.FailedByHostApp
+            "generic_error" -> AppError.GenericError
+            else -> {
+                Log.w("IdKit-Kotlin", "Unknown error: $errorString")
+                AppError.GenericError
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added logic for processing (deserialization) of new Credential Category Proof in response from the Bridge. 
- Fixed the problem of incorrect deserialization of errors.

Credential Category Proof scheme:
```
{
  "type": "object",
  "properties": {
    "proof": {
      "type": "string",
      "description": "The cryptographic proof of the credential."
    },
    "merkle_root": {
      "type": "string",
      "description": "The Merkle root for the inclusion proof."
    },
    "nullifier_hash": {
      "type": "string",
      "description": "The nullifier hash to prevent double-spending."
    },
    "verification_credential_result": {
      "type": "object",
      "additionalProperties": {
        "type": "string"
      },
      "description": "A map of key-value pairs representing the Credential verification result."
    }
  },
  "required": [
    "proof",
    "merkle_root",
    "nullifier_hash",
    "verification_credential_result"
  ],
  "additionalProperties": false
}
```