### PR TITLE
[ID-642] Extend idkit-kotlin so exceptions are surfaced as errors

### DIFF
--- a/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/CustomSerializers.kt
+++ b/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/CustomSerializers.kt
@@ -57,7 +57,7 @@ internal object AppErrorSerializer : KSerializer<AppError> {
         PrimitiveSerialDescriptor("AppError", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: AppError) {
-        throw NotImplementedError("Serialization of AppError is not supported")
+       encoder.encodeString(value.message)
     }
 
     override fun deserialize(decoder: Decoder): AppError {
@@ -81,7 +81,7 @@ internal object AppErrorSerializer : KSerializer<AppError> {
             "generic_error" -> AppError.GenericError
             else -> {
                 Log.w("IdKit-Kotlin", "Unknown error: $errorString")
-                AppError.GenericError
+                GenericAppError(errorString)
             }
         }
     }

--- a/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/Types.kt
+++ b/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/Types.kt
@@ -1,5 +1,6 @@
 package com.worldcoin.idkit_kotlin
 
+import android.annotation.SuppressLint
 import kotlinx.serialization.*
 import kotlinx.serialization.json.Json
 import java.net.URL
@@ -23,6 +24,7 @@ sealed interface Proof {
         DEVICE
     }
 
+    @SuppressLint("UnsafeOptInUsageError")
     @Serializable
     data class Default(
         val proof: String,
@@ -32,6 +34,7 @@ sealed interface Proof {
         @SerialName("verification_level") val verificationLevel: CredentialType,
     ) : Proof
 
+    @SuppressLint("UnsafeOptInUsageError")
     @Serializable
     data class CredentialCategory(
         @SerialName("proof") val proof: String,
@@ -134,11 +137,14 @@ sealed interface AppError {
     }
 }
 
+data class GenericAppError(override val message: String) : AppError
+
 internal class AppErrorThrowable(appError: AppError) : Throwable(appError.message)
 
 @Serializable
 sealed interface EncryptablePayload
 
+@SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class CreateRequestPayload(
     @SerialName("app_id") val appId: String,
@@ -178,6 +184,7 @@ data class CreateRequestPayload(
     )
 }
 
+@SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class CreateCredentialCategoryRequestPayload(
     @SerialName("app_id") val appId: String,


### PR DESCRIPTION
Currently, idkit-kotlin swallows exceptions and displays a very unhelpful "Unexpected error occurred." Since the users of this are developers, it's quite useful to surface the exact underlying exception, either because the adopters of idkit-kotlin have caused an issue in their own code, because they've found an issue in our own, or because we've goofed up and need to make a World App change.

* Extend `AppError` with a new class that wraps a string message. This is used to report exceptions as errors.
