### PR TITLE
Update types for credential categories to match the API spec

### DIFF
--- a/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/Types.kt
+++ b/idkit-kotlin/src/main/java/com/worldcoin/idkit_kotlin/Types.kt
@@ -213,12 +213,12 @@ enum class CredentialCategory {
     /**
      * The set of NFC credentials with no authentication.
      */
-    DOCUMENT,
+    @SerialName("document") DOCUMENT,
 
     /**
      * The set of NFC credentials with active or passive authentication.
      */
-    SECURE_DOCUMENT
+    @SerialName("secure_document") SECURE_DOCUMENT,
 }
 
 @Serializable


### PR DESCRIPTION
* Add an explicit mapping of the CredentialCategory to the serialized representation so it's consistent across platforms.
