### PR TITLE
Remove `local.properties` from the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 local.properties
 .kotlin/errors
 app/build
-local.properties

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Aug 08 15:06:47 PDT 2025
-sdk.dir=/Users/sean.olszewski/Library/Android/sdk


### PR DESCRIPTION
Fixes #20 

Working on this, found out that `local.properties` was already added in `.gitignore` so removing `local.properties` is enough.