### PR TITLE
Add publish to Maven Central setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ Then add the dependency:
 implementation("com.worldcoin:idkit-kotlin:3.0.0")
 ```
 
-If you cannot use GitHub Packages, please open an issue. We plan to make a Maven Central distribution available.
-
 <!-- WORLD-ID-SHARED-README-TAG:START - Do not remove or modify this section directly -->
 <!-- The contents of this file are inserted to all World ID repositories to provide general context on World ID. -->
 
@@ -101,14 +99,47 @@ All the technical docs for the Wordcoin SDK, World ID Protocol, examples, guides
 
 ## Release
 
-1. Before you release please make sure that you have updated the version in `idkit-kotlin/build.gradle.kts`.
+When publishing, you need to provide your Sonatype OSS credentials and signing GPG key, put them in your user’s home `gradle.properties` (`~/.gradle/gradle.properties`):
+
+```
+mavenCentralUsername=username
+mavenCentralPassword=the_password
+
+signing.keyId=12345678
+signing.password=some_password
+signing.secretKeyRingFile=/Users/yourusername/.gnupg/secring.gpg
+```
+
+1. Before you release please make sure that you have removed the `-SNAPSHOT` from the `libraryVersion` (`idkit-kotlin/build.gradle.kts`).
 
 2. To complete the release please perform the following:
 
 ```shell
 ./gradlew clean
 ./gradlew :idkit-kotlin:build
-./gradlew :idkit-kotlin:publishReleasePublicationToGitHubPackagesRepository
+./gradlew :idkit-kotlin:publish
+```
+
+3. Bump the major `libraryVersion` and bring the `-SNAPSHOT` back.
+
+## Publishing Commands
+
+### To Maven Central
+
+```shell
+./gradlew publishToMavenCentral
+```
+
+### To GitHub Packages
+
+```shell
+./gradlew publishAllPublicationsToGitHubPackagesRepository
+```
+
+### To both
+
+```shell
+./gradlew publish
 ```
 
 <!-- WORLD-ID-SHARED-README-TAG:END -->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.0.0"
 kotlinxSerializationJson = "1.7.1"
 material = "1.12.0"
 kotlincrypto="0.5.1"
+mavenPublish = "0.34.0"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
@@ -14,4 +15,5 @@ kotlincrypto-sha3 = { module = "org.kotlincrypto.hash:sha3", version.ref = "kotl
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 

--- a/idkit-kotlin/build.gradle.kts
+++ b/idkit-kotlin/build.gradle.kts
@@ -2,8 +2,12 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.jetbrainsKotlinAndroid)
     kotlin("plugin.serialization") version "2.0.0"
-    `maven-publish`
+    alias(libs.plugins.mavenPublish)
 }
+
+val libraryGroup = "com.worldcoin"
+val libraryArtifactId = "idkit-kotlin"
+val libraryVersion = "4.0.0-SNAPSHOT"
 
 android {
     namespace = "com.worldcoin.idkit_kotlin"
@@ -25,13 +29,6 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
 }
 
 dependencies {
@@ -40,17 +37,40 @@ dependencies {
     implementation(libs.kotlincrypto.sha3)
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                groupId = "com.worldcoin"
-                artifactId = "idkit-kotlin"
-                // Update this version when publishing
-                version = "3.0.0"
-                from(components["release"])
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+    coordinates(libraryGroup, libraryArtifactId, libraryVersion)
+
+    pom {
+        name.set("IDKit (Kotlin)")
+        description.set("The IDKit library provides a simple Kotlin interface for prompting users for World ID proofs.")
+        inceptionYear.set("2024")
+        url.set("https://github.com/worldcoin/idkit-kotlin/")
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://mit-license.org/")
+                distribution.set("https://mit-license.org/")
             }
         }
+        developers {
+            developer {
+                id.set("worldcoin")
+                name.set("Worldcoin")
+                url.set("https://github.com/worldcoin/")
+            }
+        }
+        scm {
+            url.set("https://github.com/worldcoin/idkit-kotlin/")
+            connection.set("scm:git:git://github.com/worldcoin/idkit-kotlin.git")
+            developerConnection.set("scm:git:ssh://git@github.com/worldcoin/idkit-kotlin.git")
+        }
+    }
+}
+
+afterEvaluate {
+    publishing {
         repositories {
             maven {
                 name = "GitHubPackages"


### PR DESCRIPTION
- This PR adds the publish to Maven Central setup. As part of this, `idkit-kotlin:3.0.0` was published on Maven Central and it's already available https://repo1.maven.org/maven2/com/worldcoin/idkit-kotlin/3.0.0/ :tada: 

Next step
- Add a GitHub Actions workflow to build and publish your library automatically - noting that this is not blocking the PR from merging, we can implement that in a separate one.